### PR TITLE
Modernize Python code + non-ssh user fix

### DIFF
--- a/server/src/webclient.ts
+++ b/server/src/webclient.ts
@@ -475,10 +475,6 @@ export class WebClient extends JobOwner {
 
                 const [_uname, _uid, capsString] = this.auth.sslname.split(".");
                 const caps = (capsString || "").split("~");
-                if (act.ssh_public_key != null && !caps.includes("ssh")) {
-                    this.connection.close(403);
-                    return;
-                }
 
                 await docker.ensure_ca();
                 const my_key = await crt.generate_key();
@@ -489,7 +485,7 @@ export class WebClient extends JobOwner {
                     key: my_key,
                     crt: my_crt,
                 };
-                if (act.ssh_public_key != null) {
+                if (act.ssh_public_key != null && caps.includes("ssh")) {
                     const { sshHostCaPub, sshHostCaKey } = await db.getRootVariables();
                     if (sshHostCaKey != null && sshHostCaPub != null && this.auth.user != null) {
                         try {

--- a/simpleadmin.py
+++ b/simpleadmin.py
@@ -606,7 +606,7 @@ async def ui_login(loop, c):
 
             class Root(u.AttrMap):
                 def keypress(self, size, key):
-                    if super(Dialog, self).keypress(size, key) is None:
+                    if super().keypress(size, key) is None:
                         return None
                     if key == 'enter':
                         f.set_result(True)
@@ -615,7 +615,7 @@ async def ui_login(loop, c):
                         f.set_result(False)
                         return None
                     if key == 'tab':
-                        return super(Dialog, self).keypress(size, 'down')
+                        return super().keypress(size, 'down')
                     return key
 
             usr = u.Edit(multiline=False, caption="user: ", allow_tab=False, edit_text=user)
@@ -869,7 +869,7 @@ async def ui_edit_object(loop, c, id, types):
             elif 'password' in type:
                 pass
             else:
-                raise Error("Unknown store type")
+                raise Exception("Unknown store type")
             if 'outer' in type:
                 state[name] = value
             else:


### PR DESCRIPTION
* sadmin CLI: Introduce static function `await Connection.open()` instead of `c = Connection(); await c.setup()` so that `Connection.socket` can by typed as a non-optional `WebSocketClientProtocol`

* sadmin CLI: Introduce and call `c.close()` to avoid warnings

Also, in sadmin server: Don't close the connection if the user does not have the "ssh" cap