### PR TITLE
Allow "config" to be null in a deployment

### DIFF
--- a/src/bin/sadmin/message.rs
+++ b/src/bin/sadmin/message.rs
@@ -179,7 +179,7 @@ pub struct LogOut {
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Deployment {
-    pub config: String,
+    pub config: Option<String>,
     pub end: Option<FiniteF64>,
     pub hash: String,
     pub host: u64,


### PR DESCRIPTION
Somehow the config can become null in a deployment, and this breaks sadmin listDeployments