### PR TITLE
Allow not setting "password" in /etc/simpleadmin_client.json

### DIFF
--- a/src/bin/sadmin/client_daemon.rs
+++ b/src/bin/sadmin/client_daemon.rs
@@ -930,7 +930,12 @@ impl Client {
 
         let mut auth_message = serde_json::to_vec(&ClientMessage::Auth {
             hostname: self.config.hostname.as_ref().unwrap().clone(),
-            password: self.config.password.clone(),
+            password: self
+                .config
+                .password
+                .as_ref()
+                .expect("Missing \"password\" in /etc/simpleadmin_client.json")
+                .clone(),
         })?;
         auth_message.push(30);
         write.write_all(&auth_message).await?;

--- a/src/bin/sadmin/connection.rs
+++ b/src/bin/sadmin/connection.rs
@@ -17,7 +17,7 @@ fn default_port() -> u16 {
 
 #[derive(Deserialize)]
 pub struct Config {
-    pub password: String,
+    pub password: Option<String>,
     pub server_host: Option<String>,
     pub hostname: Option<String>,
     #[serde(default = "default_port")]


### PR DESCRIPTION
The password is not needed if you do not need to run a hostclient.