### PR TITLE
Use ObjectType for key of SetInitialState types

### DIFF
--- a/src/action_types.rs
+++ b/src/action_types.rs
@@ -190,7 +190,7 @@ pub struct ISetInitialState {
     pub deployment_status: DeploymentStatus,
     pub deployment_message: String,
     pub deployment_log: Vec<String>,
-    pub types: HashMap<i64, IObject2<ValueMap>>, // TODO(jakobt) IType
+    pub types: HashMap<ObjectType, IObject2<ValueMap>>, // TODO(jakobt) IType
     pub hosts_up: Vec<i64>,
     pub used_by: Vec<(i64, i64)>,
 }

--- a/src/bin/server/webclient.rs
+++ b/src/bin/server/webclient.rs
@@ -599,7 +599,7 @@ os.execv(sys.argv[1], sys.argv[1:])
                 for row in rows {
                     let object: IObject2<ValueMap> = row.try_into().context("IObject2")?;
                     if object.r#type == ObjectType::Id(TYPE_ID) {
-                        types.insert(object.id, object.clone());
+                        types.insert(ObjectType::Id(object.id), object.clone());
                     }
                     object_names_and_ids
                         .entry(object.r#type)


### PR DESCRIPTION
Since it's a JSON object, the keys to deserialize are always strings.

Fixes errors like

	Invalid message: Error("invalid type: string \"1\", expected i64", line: 0, column: 0) at 0:0