### PR TITLE
frontend: Fix bug in getOrInsert

### DIFF
--- a/frontend/src/getOrInsert.ts
+++ b/frontend/src/getOrInsert.ts
@@ -3,7 +3,7 @@ function getDefault<K, V>(map: Map<K, V>, key: K, create: () => V): V {
     if (v !== undefined) return v;
     const vv = create();
     map.set(key, vv);
-    return vv;
+    return map.get(key)!;
 }
 
 export default getDefault;


### PR DESCRIPTION
When the map is mobxed the inserted value is copied, to make it observable we should return the observable copy