### PR TITLE
 Use same 12-hour expiry for sadmin auth, SSL certificate, and SSH certificate

### DIFF
--- a/src/bin/sadmin/client_daemon_service.rs
+++ b/src/bin/sadmin/client_daemon_service.rs
@@ -1788,7 +1788,7 @@ It will be hard killed in {:?} if it does not stop before that. ",
         bind_keys: &mut Vec<String>,
         deploy_user: String,
     ) -> Result<(ServiceInstance, ServiceStatus)> {
-        info!("Start instance {}", &desc.name);
+        info!("Start instance {}", desc.name);
 
         // Find user
         let user = match &desc.user {
@@ -2579,7 +2579,7 @@ impl client_daemon::Client {
         for (name, state) in services? {
             let status: ServiceStatus = serde_json::from_str(&state)
                 .with_context(|| format!("Unable to load state for {name}"))?;
-            info!("Restore service {}, {:?}", name, &status.process_key,);
+            info!("Restore service {}, {:?}", name, status.process_key);
             let dead = if let Some(process_key) = &status.process_key {
                 let (dead_send, dead_recv) = tokio::sync::oneshot::channel();
                 self.dead_process_handlers
@@ -2596,7 +2596,7 @@ impl client_daemon::Client {
         let process_keys = self
             .persist_list_processes(Some("service.".to_string()))
             .await?;
-        info!("Process keys {:?}", &process_keys);
+        info!("Process keys {:?}", process_keys);
         for (name, status, dead) in service_info {
             let running = status
                 .process_key

--- a/src/bin/sadmin/main.rs
+++ b/src/bin/sadmin/main.rs
@@ -115,7 +115,7 @@ async fn auth(config: Config) -> Result<()> {
     let mut con = Connection::open(config, false).await?;
     if con.authenticated() {
         con.get_key().await?;
-        println!("Already authenticated as {}.", &con.user.unwrap())
+        println!("Already authenticated as {}.", con.user.unwrap())
     } else {
         con.prompt_auth().await?;
         con.get_key().await?;

--- a/src/bin/server/crt.rs
+++ b/src/bin/server/crt.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use chrono::{TimeDelta, Utc};
 use std::io::Write;
 use tempfile::{NamedTempFile, TempDir};
 
@@ -104,14 +105,18 @@ pub async fn generate_srs(key: &str, cn: &str) -> Result<String> {
     Ok(String::from_utf8(res.stdout)?)
 }
 
+/// For both SSL and SSH certificates, set the start time a few minutes into the past
+/// to avoid issues with clock drift.
+const CERT_VALIDITY_IN_THE_PAST: TimeDelta = TimeDelta::minutes(5);
+
 pub async fn generate_crt(
     ca_key: &str,
     ca_crt: &str,
     srs: &str,
     subcerts: &[String],
-    timeout_days: u32,
+    timeout_duration: TimeDelta,
 ) -> Result<String> {
-    generate_crt_san(ca_key, ca_crt, srs, subcerts, &[], timeout_days).await
+    generate_crt_san(ca_key, ca_crt, srs, subcerts, &[], timeout_duration).await
 }
 
 pub async fn generate_crt_san(
@@ -120,7 +125,7 @@ pub async fn generate_crt_san(
     srs: &str,
     subcerts: &[String],
     sans: &[String],
-    timeout_days: u32,
+    timeout_duration: TimeDelta,
 ) -> Result<String> {
     let mut t1 = NamedTempFile::new()?;
     let mut t2 = NamedTempFile::new()?;
@@ -133,8 +138,13 @@ pub async fn generate_crt_san(
     let mut cmd = tokio::process::Command::new("openssl");
     cmd.arg("x509");
     cmd.arg("-req");
-    cmd.arg("-days");
-    cmd.arg(timeout_days.to_string());
+    // -not_before/-not_after YYYYMMDDHHMMSSZ sets the precise expiry time (in UTC).
+    let not_before = (Utc::now() - CERT_VALIDITY_IN_THE_PAST).format("%Y%m%d%H%M%SZ");
+    let not_after = (Utc::now() + timeout_duration).format("%Y%m%d%H%M%SZ");
+    cmd.arg("-not_before");
+    cmd.arg(not_before.to_string());
+    cmd.arg("-not_after");
+    cmd.arg(not_after.to_string());
     cmd.arg("-in");
     cmd.arg(t1.path());
     cmd.arg("-CA");
@@ -200,7 +210,7 @@ pub async fn generate_ssh_crt(
     principal: &str,
     ca_private_key: &str,
     client_public_key: &str,
-    validity_days: u32,
+    validity_duration: TimeDelta,
     r#type: Type,
 ) -> Result<String> {
     let mut ssh_host_ca_key_file = NamedTempFile::with_suffix(".pem")?;
@@ -225,7 +235,10 @@ pub async fn generate_ssh_crt(
     cmd.arg("-n");
     cmd.arg(principal);
     cmd.arg("-V");
-    cmd.arg(format!("-5m:+{validity_days}d"));
+    // -V YYYYMMDDHHMMSSZ:YYYYMMDDHHMMSSZ sets the precise expiry time (in UTC).
+    let not_before = (Utc::now() - CERT_VALIDITY_IN_THE_PAST).format("%Y%m%d%H%M%SZ");
+    let not_after = (Utc::now() + validity_duration).format("%Y%m%d%H%M%SZ");
+    cmd.arg(format!("{not_before}:{not_after}"));
     cmd.arg("-z");
     cmd.arg("42");
     cmd.arg(&client_public_key_path);

--- a/src/bin/server/deployment.rs
+++ b/src/bin/server/deployment.rs
@@ -1640,7 +1640,7 @@ async fn perform_deploy(rt: &RunToken, state: &State, mark_only: bool) -> Result
         }
         set_location!(rt);
         mut_deployment(state, |deployment| {
-            deployment.add_header(&format!("{} ({})", &object.title, &object.type_name), false);
+            deployment.add_header(&format!("{} ({})", object.title, object.type_name), false);
             deployment.set_object_status(index, DeploymentObjectStatus::Deplying);
             Ok(())
         })

--- a/src/bin/server/docker.rs
+++ b/src/bin/server/docker.rs
@@ -10,6 +10,7 @@ use crate::{
     webclient::{self, WebClient},
 };
 
+use chrono::TimeDelta;
 use sadmin2::{
     action_types::IDockerDeployLog,
     client_message::{DataMessage, DeployServiceMessage, FailureMessage, SuccessMessage},
@@ -442,9 +443,10 @@ async fn deploy_server_inner2(
                 Some(Subcert::More(vec)) => vec,
                 None => Vec::new(),
             };
-            let my_crt = crt::generate_crt(ca_key, ca_crt, &my_srs, &ssl_subcerts, 999)
-                .await
-                .context("generate_crt")?;
+            let my_crt =
+                crt::generate_crt(ca_key, ca_crt, &my_srs, &ssl_subcerts, TimeDelta::days(999))
+                    .await
+                    .context("generate_crt")?;
             variables.insert("ca_pem".into(), crt::strip(ca_crt).to_string().into());
             variables.insert("ssl_key".into(), crt::strip(&my_key).to_string().into());
             variables.insert("ssl_pem".into(), crt::strip(&my_crt).to_string().into());

--- a/src/bin/server/get_auth.rs
+++ b/src/bin/server/get_auth.rs
@@ -1,6 +1,12 @@
 use crate::{action_types::IAuthStatus, db::get_user_content, state::State};
 use anyhow::{Context, Result};
+use chrono::TimeDelta;
 use qusql_sqlx_type::query;
+
+/// How often the user must run 'sadmin auth' to retype their password.
+const USER_REAUTH_INTERVAL: TimeDelta = TimeDelta::hours(12);
+/// How often the user must run 'sadmin auth' and re-validate with 2nd factor (TOTP).
+const USER_REAUTH_OTP_INTERVAL: TimeDelta = TimeDelta::days(64);
 
 pub async fn get_auth(state: &State, host: Option<&str>, sid: Option<&str>) -> Result<IAuthStatus> {
     let Some(sid) = sid else {
@@ -94,19 +100,19 @@ pub async fn get_auth(state: &State, host: Option<&str>, sid: Option<&str>) -> R
         };
 
         let auth_days = content.auth_days.and_then(|v| v.parse::<u32>().ok());
-        let pwd_expiration: i64 = if &user == "docker_client" {
-            60 * 60
+        let pwd_expiration = if &user == "docker_client" {
+            TimeDelta::hours(1)
         } else if let Some(auth_days) = auth_days {
-            auth_days as i64 * 60 * 60 * 24
+            TimeDelta::days(auth_days as i64)
         } else {
-            12 * 60 * 60 //Passwords time out after 12 hours
+            USER_REAUTH_INTERVAL
         };
 
-        let otp_expiration: i64 = if &user == "docker_client" {
-            60 * 60
+        let otp_expiration = if &user == "docker_client" {
+            TimeDelta::hours(1)
         } else {
-            64 * 24 * 60 * 60
-        }; //otp time out after 2 months
+            USER_REAUTH_OTP_INTERVAL
+        };
 
         let now = std::time::SystemTime::now();
         let now = now
@@ -115,11 +121,11 @@ pub async fn get_auth(state: &State, host: Option<&str>, sid: Option<&str>) -> R
             .as_secs() as i64;
         let pwd = row
             .pwd
-            .map(|v| v + pwd_expiration > now)
+            .map(|v| v + pwd_expiration.num_seconds() > now)
             .unwrap_or_default();
         let otp = row
             .otp
-            .map(|v| v + i64::max(otp_expiration, pwd_expiration) > now)
+            .map(|v| v + i64::max(otp_expiration.num_seconds(), pwd_expiration.num_seconds()) > now)
             .unwrap_or_default();
 
         Ok(IAuthStatus {

--- a/src/bin/server/get_auth.rs
+++ b/src/bin/server/get_auth.rs
@@ -4,7 +4,11 @@ use chrono::TimeDelta;
 use qusql_sqlx_type::query;
 
 /// How often the user must run 'sadmin auth' to retype their password.
-const USER_REAUTH_INTERVAL: TimeDelta = TimeDelta::hours(12);
+/// This timeout is used for three kinds of authentication expiry:
+/// - get_auth(), which checks the session age on every request to the sadmin server
+/// - handle_generate_key(), generating the user's SSL certificate (for talking to services)
+/// - handle_generate_key(), generating the user's SSH certificate (for connecting to servers)
+pub const USER_REAUTH_INTERVAL: TimeDelta = TimeDelta::hours(12);
 /// How often the user must run 'sadmin auth' and re-validate with 2nd factor (TOTP).
 const USER_REAUTH_OTP_INTERVAL: TimeDelta = TimeDelta::days(64);
 

--- a/src/bin/server/hostclient.rs
+++ b/src/bin/server/hostclient.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use bytes::{Buf, BytesMut};
+use chrono::TimeDelta;
 use log::{error, info, warn};
 use qusql_sqlx_type::query;
 use rand::RngExt;
@@ -546,7 +547,7 @@ impl HostClient {
         let r = db::get_root_variables(state).await?;
         set_location!(rt);
         if let Some(ssh_host_ca_key) = r.get("sshHostCaKey") {
-            const VALIDITY_DAYS: u32 = 7;
+            const SSH_CRT_VALIDITY: TimeDelta = TimeDelta::days(7);
             set_location!(rt);
             let ssh_crt: String = crt::generate_ssh_crt(
                 &format!("{} sadmin host", self.hostname),
@@ -556,7 +557,7 @@ impl HostClient {
                 ),
                 ssh_host_ca_key,
                 &host_key,
-                VALIDITY_DAYS,
+                SSH_CRT_VALIDITY,
                 crt::Type::Host,
             )
             .await?;
@@ -656,7 +657,7 @@ impl HostClient {
             Some(domain) if !domain.is_empty() => format!("{}.{}", nodename, domain),
             _ => nodename.clone(),
         };
-        const VALIDITY_DAYS: u32 = 9999;
+        const NFS_TLS_VALIDITY: TimeDelta = TimeDelta::days(9999);
         set_location!(rt);
         let (ca_key, ca_crt) = nfs_group_ca(state, &nfs_group).await?;
         let mut sans = vec![self.hostname.clone(), nodename.clone(), cn.clone()];
@@ -666,12 +667,14 @@ impl HostClient {
         let server_key = crt::generate_key().await?;
         let server_srs = crt::generate_srs(&server_key, &cn).await?;
         let server_crt =
-            crt::generate_crt_san(&ca_key, &ca_crt, &server_srs, &[], &sans, VALIDITY_DAYS).await?;
+            crt::generate_crt_san(&ca_key, &ca_crt, &server_srs, &[], &sans, NFS_TLS_VALIDITY)
+                .await?;
         set_location!(rt);
         let client_key = crt::generate_key().await?;
         let client_srs = crt::generate_srs(&client_key, &cn).await?;
         let client_crt =
-            crt::generate_crt_san(&ca_key, &ca_crt, &client_srs, &[], &sans, VALIDITY_DAYS).await?;
+            crt::generate_crt_san(&ca_key, &ca_crt, &client_srs, &[], &sans, NFS_TLS_VALIDITY)
+                .await?;
         set_location!(rt);
         self.run_shell("mkdir -p /etc/nfs-tls && chmod 700 /etc/nfs-tls".into())
             .await?;

--- a/src/bin/server/webclient.rs
+++ b/src/bin/server/webclient.rs
@@ -36,7 +36,7 @@ use crate::{
     deployment,
     docker::{deploy_service, list_deployment_history, list_deployments, redploy_service},
     docker_web,
-    get_auth::get_auth,
+    get_auth::{USER_REAUTH_INTERVAL, get_auth},
     hostclient::{HostClient, JobHandle},
     modified_files, msg, setup,
     state::{LoginAttempts, State},
@@ -236,7 +236,8 @@ impl WebClient {
                         user,
                         ssh_host_ca_key,
                         &ssh_public_key,
-                        TimeDelta::days(1),
+                        // Use same validity for SSL certificate and SSH certificate
+                        auth_duration,
                         crt::Type::User,
                     )
                     .await?,
@@ -262,8 +263,14 @@ impl WebClient {
             self.close(403).await?;
             return Ok(());
         };
+        // "auth_days" can be used to extend the validity of SSL and SSH certificates
+        let auth_duration = if let Some(days) = auth.auth_days {
+            TimeDelta::days(days as i64)
+        } else {
+            USER_REAUTH_INTERVAL
+        };
         let res = match Self::handle_generate_key_inner(
-            TimeDelta::days(auth.auth_days.unwrap_or(1)),
+            auth_duration,
             auth.user.as_deref(),
             sslname,
             state,

--- a/src/bin/server/webclient.rs
+++ b/src/bin/server/webclient.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, bail};
 use base64::{Engine, prelude::BASE64_STANDARD};
 use bytes::Bytes;
+use chrono::TimeDelta;
 use futures::{
     SinkExt, StreamExt,
     stream::{SplitSink, SplitStream},
@@ -199,7 +200,7 @@ impl WebClient {
     }
 
     async fn handle_generate_key_inner(
-        auth_days: u32,
+        auth_duration: TimeDelta,
         auth_user: Option<&str>,
         sslname: String,
         state: &State,
@@ -212,7 +213,7 @@ impl WebClient {
         let ca_crt = &state.docker.ca_crt;
         let key = crt::generate_key().await?;
         let srs = crt::generate_srs(&key, &format!("{sslname}.user")).await?;
-        let crt = crt::generate_crt(ca_key, ca_crt, &srs, &[], auth_days).await?;
+        let crt = crt::generate_crt(ca_key, ca_crt, &srs, &[], auth_duration).await?;
         let mut res = IGenerateKeyRes {
             r#ref: act.r#ref,
             ca_pem: ca_crt.clone(),
@@ -235,7 +236,7 @@ impl WebClient {
                         user,
                         ssh_host_ca_key,
                         &ssh_public_key,
-                        1,
+                        TimeDelta::days(1),
                         crt::Type::User,
                     )
                     .await?,
@@ -262,7 +263,7 @@ impl WebClient {
             return Ok(());
         };
         let res = match Self::handle_generate_key_inner(
-            auth.auth_days.unwrap_or(1),
+            TimeDelta::days(auth.auth_days.unwrap_or(1)),
             auth.user.as_deref(),
             sslname,
             state,


### PR DESCRIPTION
Currently only the sadmin server API uses a 12-hour expiry - when talking to sadmin services or connecting with SSH, the certificates have 24-hour expiry.

Change this to be consistently 12 hours throughout. This requires a bit of refactoring as many internal functions are written to take an integer number of days. Switch to chrono::TimeDelta as much as possible.

I didn't test these changes - I only checked with `cargo clippy --features server --bin simpleadmin-server` that I didn't introduce any new clippy lints.